### PR TITLE
Add `secretjs.tx.simulate()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,12 +896,12 @@ const tx = await secretjs.tx.broadcast([addMinterMsg, mintMsg], {
 
 Used to simulate a complex transactions, which contains a list of messages, without broadcasting it to the chain. Can be used to get a gas estimation or to see the output without actually committing a transaction on-chain.
 
-The input should be exactly how you'd use it in `secretjs.tx.broadcast()`.
+The input should be exactly how you'd use it in `secretjs.tx.broadcast()`, except that you don't have to pass in `gasLimit`, `gasPriceInFeeDenom` & `feeDenom`.
 
-Caveates:
+Notes:
 
-1. Gas estimation is known to be a bit off, so you might need to adjust it a bit before broadcasting.
-2. Simulation is not available for `MsgInstantiate`, `MsgExecute` & `MsgStore`.
+- On mainnet it's recommended to not simulate every transaction as this can burden your node provider. Instead, use this while testing to determine the gas limit for each of your app's transactions, then in production use hard-coded values.
+- Gas estimation is known to be a bit off, so you might need to adjust it a bit before broadcasting.
 
 ```ts
 const sendToAlice = new MsgSend({
@@ -916,13 +916,11 @@ const sendToEve = new MsgSend({
   amount: [{ denom: "uscrt", amount: "1" }],
 });
 
-const sim = await secretjs.tx.simulate([sendToAlice, sendToEve], {
-  gasLimit: 100_000,
-});
+const sim = await secretjs.tx.simulate([sendToAlice, sendToEve]);
 
 const tx = await secretjs.tx.broadcast([sendToAlice, sendToEve], {
-  // Adjust gasLimit up by 15% to account for gas estimation error
-  gasLimit: Math.ceil(sim.gasInfo.gasUsed * 1.15),
+  // Adjust gasLimit up by 10% to account for gas estimation error
+  gasLimit: Math.ceil(sim.gasInfo.gasUsed * 1.1),
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -892,11 +892,49 @@ const tx = await secretjs.tx.broadcast([addMinterMsg, mintMsg], {
 });
 ```
 
+#### `secretjs.tx.simulate()`
+
+Used to simulate a complex transactions, which contains a list of messages, without broadcasting it to the chain. Can be used to get a gas estimation or to see the output without actually commiting a transaction on-chain.
+
+The input should be exactly how you'd use it in `secretjs.tx.broadcast()`.
+
+Caveates:
+
+1. Gas estimation is known to be a bit off, so you might need to adjust it a bit before broadcasting.
+2. Simulation is not available for `MsgInstantiate`, `MsgExecute` & `MsgStore`.
+
+```ts
+const sendToAlice = new MsgSend({
+  fromAddress: bob,
+  toAddress: alice,
+  amount: [{ denom: "uscrt", amount: "1" }],
+});
+
+const sendToEve = new MsgSend({
+  fromAddress: bob,
+  toAddress: eve,
+  amount: [{ denom: "uscrt", amount: "1" }],
+});
+
+const sim = await secretjs.tx.simulate([sendToAlice, sendToEve], {
+  gasLimit: 100_000,
+});
+
+const tx = await secretjs.tx.broadcast([sendToAlice, sendToEve], {
+  // Adjust gasLimit up by 15% to account for gas estimation error
+  gasLimit: Math.ceil(sim.gasInfo.gasUsed * 1.15),
+});
+```
+
 #### `secretjs.tx.authz.exec()`
 
 MsgExec attempts to execute the provided messages using authorizations granted to the grantee. Each message should have only one signer corresponding to the granter of the authorization.
 
 Input: [MsgExecParams](https://secretjs.scrt.network/interfaces/MsgExecParams)
+
+##### `secretjs.tx.authz.exec.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
 
 #### `secretjs.tx.authz.grant()`
 
@@ -904,11 +942,19 @@ MsgGrant is a request type for Grant method. It declares authorization to the gr
 
 Input: [MsgGrantParams](https://secretjs.scrt.network/interfaces/MsgGrantParams)
 
+##### `secretjs.tx.authz.grant.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
+
 #### `secretjs.tx.authz.revoke()`
 
 MsgRevoke revokes any authorization with the provided sdk.Msg type on the granter's account with that has been granted to the grantee.
 
 Input: [MsgRevokeParams](https://secretjs.scrt.network/interfaces/MsgRevokeParams)
+
+##### `secretjs.tx.authz.revoke.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
 
 #### `secretjs.tx.bank.multiSend()`
 
@@ -942,6 +988,10 @@ const tx = await secretjs.tx.bank.multiSend(
 );
 ```
 
+    ##### `secretjs.tx.bank.multiSend.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
+
 #### `secretjs.tx.bank.send()`
 
 MsgSend represents a message to send coins from one account to another.
@@ -960,6 +1010,10 @@ const tx = await secretjs.tx.bank.send(
   },
 );
 ```
+
+##### `secretjs.tx.bank.send.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
 
 #### `secretjs.tx.compute.storeCode()`
 
@@ -988,11 +1042,17 @@ const codeId = Number(
 );
 ```
 
+##### `secretjs.tx.compute.storeCode.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
+
 #### `secretjs.tx.compute.instantiateContract()`
 
 Instantiate a contract from code id
 
-Input: [MsgInstantiateContractParams](https://secretjs.scrt.network/interfaces/MsgInstantiateContractParams)
+Input: [MsgInstantiateContractParams](https://secretjs.scrt.network/interfaces/MsgInstanti
+
+ateContractParams)
 
 ```ts
 const tx = await secretjs.tx.compute.instantiateContract(
@@ -1029,6 +1089,10 @@ const contractAddress = tx.arrayLog.find(
 ).value;
 ```
 
+##### `secretjs.tx.compute.instantiateContract.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
+
 #### `secretjs.tx.compute.executeContract()`
 
 Execute a function on a contract
@@ -1055,11 +1119,19 @@ const tx = await secretjs.tx.compute.executeContract(
 );
 ```
 
+##### `secretjs.tx.compute.executeContract.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
+
 #### `secretjs.tx.crisis.verifyInvariant()`
 
 MsgVerifyInvariant represents a message to verify a particular invariance.
 
 Input: [MsgVerifyInvariantParams](https://secretjs.scrt.network/interfaces/MsgVerifyInvariantParams)
+
+##### `secretjs.tx.crisis.verifyInvariant.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
 
 #### `secretjs.tx.distribution.fundCommunityPool()`
 
@@ -1079,6 +1151,10 @@ const tx = await secretjs.tx.distribution.fundCommunityPool(
 );
 ```
 
+##### `secretjs.tx.distribution.fundCommunityPool.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
+
 #### `secretjs.tx.distribution.setWithdrawAddress()`
 
 MsgSetWithdrawAddress sets the withdraw address for a delegator (or validator self-delegation).
@@ -1097,11 +1173,17 @@ const tx = await secretjs.tx.distribution.setWithdrawAddress(
 );
 ```
 
+##### `secretjs.tx.distribution.setWithdrawAddress.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
+
 #### `secretjs.tx.distribution.withdrawDelegatorReward()`
 
 MsgWithdrawDelegatorReward represents delegation withdrawal to a delegator from a single validator.
 
-Input: [MsgWithdrawDelegatorRewardParams](https://secretjs.scrt.network/interfaces/MsgWithdrawDelegatorRewardParams)
+Input: [MsgWithdrawDelegatorRewardParams](https://secretjs.scrt.network/interfaces/MsgWithdraw
+
+DelegatorRewardParams)
 
 ```ts
 const tx = await secretjs.tx.distribution.withdrawDelegatorReward(
@@ -1115,11 +1197,17 @@ const tx = await secretjs.tx.distribution.withdrawDelegatorReward(
 );
 ```
 
+##### `secretjs.tx.distribution.withdrawDelegatorReward.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
+
 #### `secretjs.tx.distribution.withdrawValidatorCommission()`
 
 MsgWithdrawValidatorCommission withdraws the full commission to the validator address.
 
-Input: [MsgWithdrawValidatorCommissionParams](https://secretjs.scrt.network/interfaces/MsgWithdrawValidatorCommissionParams)
+Input: [MsgWithdrawValidatorCommissionParams](https://secretjs.scrt.network/interfaces/MsgWithdraw
+
+ValidatorCommissionParams)
 
 ```ts
 const tx = await secretjs.tx.distribution.withdrawValidatorCommission(
@@ -1151,11 +1239,19 @@ const tx = await secretjs.tx.broadcast(
 );
 ```
 
+##### `secretjs.tx.distribution.withdrawValidatorCommission.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
+
 #### `secretjs.tx.evidence.submitEvidence()`
 
 MsgSubmitEvidence represents a message that supports submitting arbitrary evidence of misbehavior such as equivocation or counterfactual signing.
 
 Input: [MsgSubmitEvidenceParams](https://secretjs.scrt.network/interfaces/MsgSubmitEvidenceParams)
+
+##### `secretjs.tx.evidence.submitEvidence.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
 
 #### `secretjs.tx.feegrant.grantAllowance()`
 
@@ -1163,11 +1259,19 @@ MsgGrantAllowance adds permission for Grantee to spend up to Allowance of fees f
 
 Input: [MsgGrantAllowanceParams](https://secretjs.scrt.network/interfaces/MsgGrantAllowanceParams)
 
+##### `secretjs.tx.feegrant.grantAllowance.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
+
 #### `secretjs.tx.feegrant.revokeAllowance()`
 
 MsgRevokeAllowance removes any existing Allowance from Granter to Grantee.
 
 Input: [MsgRevokeAllowanceParams](https://secretjs.scrt.network/interfaces/MsgRevokeAllowanceParams)
+
+##### `secretjs.tx.feegrant.revokeAllowance.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
 
 #### `secretjs.tx.gov.deposit()`
 
@@ -1187,6 +1291,10 @@ const tx = await secretjs.tx.gov.deposit(
   },
 );
 ```
+
+##### `secretjs.tx.gov.deposit.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
 
 #### `secretjs.tx.gov.submitProposal()`
 
@@ -1217,6 +1325,10 @@ const proposalId = Number(
 );
 ```
 
+##### `secretjs.tx.gov.submitProposal.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
+
 #### `secretjs.tx.gov.vote()`
 
 MsgVote defines a message to cast a vote.
@@ -1235,6 +1347,10 @@ const tx = await secretjs.tx.gov.vote(
   },
 );
 ```
+
+##### `secretjs.tx.gov.vote.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
 
 #### `secretjs.tx.gov.voteWeighted()`
 
@@ -1260,11 +1376,19 @@ const tx = await secretjs.tx.gov.voteWeighted(
 );
 ```
 
+##### `secretjs.tx.gov.voteWeighted.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
+
 #### `secretjs.tx.ibc.transfer()`
 
 MsgTransfer defines a msg to transfer fungible tokens (i.e Coins) between ICS20 enabled chains. See ICS Spec here: https://github.com/cosmos/ics/tree/master/spec/ics-020-fungible-token-transfer#data-structures
 
 Input: [MsgTransferParams](https://secretjs.scrt.network/interfaces/MsgTransferParams)
+
+##### `secretjs.tx.ibc.transfer.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
 
 #### `secretjs.tx.slashing.unjail()`
 
@@ -1282,6 +1406,10 @@ const tx = await secretjs.tx.slashing.unjail(
   },
 );
 ```
+
+##### `secretjs.tx.slashing.unjail.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
 
 #### `secretjs.tx.staking.beginRedelegate()`
 
@@ -1302,6 +1430,10 @@ const tx = await secretjs.tx.staking.beginRedelegate(
   },
 );
 ```
+
+##### `secretjs.tx.staking.beginRedelegate.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
 
 #### `secretjs.tx.staking.createValidator()`
 
@@ -1335,6 +1467,10 @@ const tx = await secretjs.tx.staking.createValidator(
 );
 ```
 
+##### `secretjs.tx.staking.createValidator.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
+
 #### `secretjs.tx.staking.delegate()`
 
 MsgDelegate defines an SDK message for performing a delegation of coins from a delegator to a validator.
@@ -1353,6 +1489,10 @@ const tx = await secretjs.tx.staking.delegate(
   },
 );
 ```
+
+##### `secretjs.tx.staking.delegate.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
 
 #### `secretjs.tx.staking.editValidator()`
 
@@ -1381,6 +1521,10 @@ const tx = await secretjs.tx.staking.editValidator(
 );
 ```
 
+##### `secretjs.tx.staking.editValidator.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).
+
 #### `secretjs.tx.staking.undelegate()`
 
 MsgUndelegate defines an SDK message for performing an undelegation from a delegate and a validator
@@ -1399,3 +1543,7 @@ const tx = await secretjs.tx.staking.undelegate(
   },
 );
 ```
+
+##### `secretjs.tx.staking.undelegate.simulate()`
+
+Simulates execution without sending a transactions. Input is exactly like the parent function. For more info see [`secretjs.tx.simulate()`](#secretjstxsimulate).

--- a/README.md
+++ b/README.md
@@ -894,7 +894,7 @@ const tx = await secretjs.tx.broadcast([addMinterMsg, mintMsg], {
 
 #### `secretjs.tx.simulate()`
 
-Used to simulate a complex transactions, which contains a list of messages, without broadcasting it to the chain. Can be used to get a gas estimation or to see the output without actually commiting a transaction on-chain.
+Used to simulate a complex transactions, which contains a list of messages, without broadcasting it to the chain. Can be used to get a gas estimation or to see the output without actually committing a transaction on-chain.
 
 The input should be exactly how you'd use it in `secretjs.tx.broadcast()`.
 

--- a/src/secret_network_client.ts
+++ b/src/secret_network_client.ts
@@ -113,11 +113,11 @@ export type CreateClientOptions = {
 };
 
 /**
- * MsgTx is a function that broadcasts a single message transaction.
+ * SingleMsgTx is a function that broadcasts a single message transaction.
  * It also has a `simulate()` method to execute the transaction without
  * committing it on-chain. This is helpful for gas estimation.
  */
-export type MsgTx<T> = {
+export type SingleMsgTx<T> = {
   (params: T, txOptions?: TxOptions): Promise<Tx>;
   simulate(
     params: T,
@@ -397,9 +397,9 @@ export type TxSender = {
   >;
 
   snip721: {
-    send: MsgTx<MsgExecuteContractParams<Snip721SendOptions>>;
-    setViewingKey: MsgTx<SetViewingKeyContractParams>;
-    createViewingKey: MsgTx<CreateViewingKeyContractParams>;
+    send: SingleMsgTx<MsgExecuteContractParams<Snip721SendOptions>>;
+    setViewingKey: SingleMsgTx<SetViewingKeyContractParams>;
+    createViewingKey: SingleMsgTx<CreateViewingKeyContractParams>;
   };
 
   snip20: {
@@ -408,16 +408,16 @@ export type TxSender = {
     //getTransferHistory
     //getAllowance
     //getMinters
-    send: MsgTx<MsgExecuteContractParams<Snip20SendOptions>>;
-    transfer: MsgTx<MsgExecuteContractParams<Snip20TransferOptions>>;
-    increaseAllowance: MsgTx<
+    send: SingleMsgTx<MsgExecuteContractParams<Snip20SendOptions>>;
+    transfer: SingleMsgTx<MsgExecuteContractParams<Snip20TransferOptions>>;
+    increaseAllowance: SingleMsgTx<
       MsgExecuteContractParams<Snip20IncreaseAllowanceOptions>
     >;
-    decreaseAllowance: MsgTx<
+    decreaseAllowance: SingleMsgTx<
       MsgExecuteContractParams<Snip20DecreaseAllowanceOptions>
     >;
-    setViewingKey: MsgTx<SetViewingKeyContractParams>;
-    createViewingKey: MsgTx<CreateViewingKeyContractParams>;
+    setViewingKey: SingleMsgTx<SetViewingKeyContractParams>;
+    createViewingKey: SingleMsgTx<CreateViewingKeyContractParams>;
   };
 
   authz: {
@@ -426,86 +426,86 @@ export type TxSender = {
      * authorizations granted to the grantee. Each message should have only
      * one signer corresponding to the granter of the authorization.
      */
-    exec: MsgTx<MsgExecParams>;
+    exec: SingleMsgTx<MsgExecParams>;
     /**
      * MsgGrant is a request type for Grant method. It declares authorization to the grantee
      * on behalf of the granter with the provided expiration time.
      */
-    grant: MsgTx<MsgGrantParams>;
+    grant: SingleMsgTx<MsgGrantParams>;
     /**
      * MsgRevoke revokes any authorization with the provided sdk.Msg type on the
      * granter's account with that has been granted to the grantee.
      */
-    revoke: MsgTx<MsgRevokeParams>;
+    revoke: SingleMsgTx<MsgRevokeParams>;
   };
   bank: {
     /** MsgMultiSend represents an arbitrary multi-in, multi-out send message. */
-    multiSend: MsgTx<MsgMultiSendParams>;
+    multiSend: SingleMsgTx<MsgMultiSendParams>;
     /** MsgSend represents a message to send coins from one account to another. */
-    send: MsgTx<MsgSendParams>;
+    send: SingleMsgTx<MsgSendParams>;
   };
   compute: {
     /** Execute a function on a contract */
-    executeContract: MsgTx<MsgExecuteContractParams<object>>;
+    executeContract: SingleMsgTx<MsgExecuteContractParams<object>>;
     /** Instantiate a contract from code id */
-    instantiateContract: MsgTx<MsgInstantiateContractParams>;
+    instantiateContract: SingleMsgTx<MsgInstantiateContractParams>;
     /** Upload a compiled contract to Secret Network */
-    storeCode: MsgTx<MsgStoreCodeParams>;
+    storeCode: SingleMsgTx<MsgStoreCodeParams>;
   };
   crisis: {
     /** MsgVerifyInvariant represents a message to verify a particular invariance. */
-    verifyInvariant: MsgTx<MsgVerifyInvariantParams>;
+    verifyInvariant: SingleMsgTx<MsgVerifyInvariantParams>;
   };
   distribution: {
     /**
      * MsgFundCommunityPool allows an account to directly
      * fund the community pool.
      */
-    fundCommunityPool: MsgTx<MsgFundCommunityPoolParams>;
+    fundCommunityPool: SingleMsgTx<MsgFundCommunityPoolParams>;
     /**
      * MsgSetWithdrawAddress sets the withdraw address for
      * a delegator (or validator self-delegation).
      */
-    setWithdrawAddress: MsgTx<MsgSetWithdrawAddressParams>;
+    setWithdrawAddress: SingleMsgTx<MsgSetWithdrawAddressParams>;
     /**
      * MsgWithdrawDelegatorReward represents delegation withdrawal to a delegator
      * from a single validator.
      */
-    withdrawDelegatorReward: MsgTx<MsgWithdrawDelegatorRewardParams>;
+    withdrawDelegatorReward: SingleMsgTx<MsgWithdrawDelegatorRewardParams>;
     /**
      * MsgWithdrawValidatorCommission withdraws the full commission to the validator
      * address.
      */
-    withdrawValidatorCommission: MsgTx<MsgWithdrawValidatorCommissionParams>;
+    withdrawValidatorCommission: SingleMsgTx<MsgWithdrawValidatorCommissionParams>;
   };
   evidence: {
     /**
      * MsgSubmitEvidence represents a message that supports submitting arbitrary
      * Evidence of misbehavior such as equivocation or counterfactual signing.
      */
-    submitEvidence: MsgTx<MsgSubmitEvidenceParams>;
+    submitEvidence: SingleMsgTx<MsgSubmitEvidenceParams>;
   };
   feegrant: {
     /**
      * MsgGrantAllowance adds permission for Grantee to spend up to Allowance
      * of fees from the account of Granter.
      */
-    grantAllowance: MsgTx<MsgGrantAllowanceParams>;
+    grantAllowance: SingleMsgTx<MsgGrantAllowanceParams>;
     /** MsgRevokeAllowance removes any existing Allowance from Granter to Grantee. */
-    revokeAllowance: MsgTx<MsgRevokeAllowanceParams>;
+    revokeAllowance: SingleMsgTx<MsgRevokeAllowanceParams>;
   };
   gov: {
     /** MsgDeposit defines a message to submit a deposit to an existing proposal. */
-    deposit: MsgTx<MsgDepositParams>;
+    deposit: SingleMsgTx<MsgDepositParams>;
     /**
      * MsgSubmitProposal defines an sdk.Msg type that supports submitting arbitrary
      * proposal Content.
      */
-    submitProposal: MsgTx<MsgSubmitProposalParams>;
+    submitProposal: SingleMsgTx<MsgSubmitProposalParams>;
     /** MsgVote defines a message to cast a vote. */
-    vote: MsgTx<MsgVoteParams>;
+    vote: SingleMsgTx<MsgVoteParams>;
     /** MsgVoteWeighted defines a message to cast a vote, with an option to split the vote. */
-    voteWeighted: MsgTx<MsgVoteWeightedParams>;
+    voteWeighted: SingleMsgTx<MsgVoteWeightedParams>;
   };
   ibc: {
     /**
@@ -513,23 +513,23 @@ export type TxSender = {
      * ICS20 enabled chains. See ICS Spec here:
      * https://github.com/cosmos/ics/tree/master/spec/ics-020-fungible-token-transfer#data-structures
      */
-    transfer: MsgTx<MsgTransferParams>;
+    transfer: SingleMsgTx<MsgTransferParams>;
   };
   slashing: {
     /** MsgUnjail defines a message to release a validator from jail. */
-    unjail: MsgTx<MsgUnjailParams>;
+    unjail: SingleMsgTx<MsgUnjailParams>;
   };
   staking: {
     /** MsgBeginRedelegate defines an SDK message for performing a redelegation of coins from a delegator and source validator to a destination validator. */
-    beginRedelegate: MsgTx<MsgBeginRedelegateParams>;
+    beginRedelegate: SingleMsgTx<MsgBeginRedelegateParams>;
     /** MsgCreateValidator defines an SDK message for creating a new validator. */
-    createValidator: MsgTx<MsgCreateValidatorParams>;
+    createValidator: SingleMsgTx<MsgCreateValidatorParams>;
     /** MsgDelegate defines an SDK message for performing a delegation of coins from a delegator to a validator. */
-    delegate: MsgTx<MsgDelegateParams>;
+    delegate: SingleMsgTx<MsgDelegateParams>;
     /** MsgEditValidator defines an SDK message for editing an existing validator. */
-    editValidator: MsgTx<MsgEditValidatorParams>;
+    editValidator: SingleMsgTx<MsgEditValidatorParams>;
     /** MsgUndelegate defines an SDK message for performing an undelegation from a delegate and a validator */
-    undelegate: MsgTx<MsgUndelegateParams>;
+    undelegate: SingleMsgTx<MsgUndelegateParams>;
   };
 };
 
@@ -659,7 +659,7 @@ export class SecretNetworkClient {
     this.utils = { accessControl: { permit: new PermitSigner(this.wallet) } };
 
     // TODO fix this any
-    const doMsg = (msgClass: any): MsgTx<any> => {
+    const doMsg = (msgClass: any): SingleMsgTx<any> => {
       const func = (params: MsgParams, options?: TxOptions) => {
         return this.tx.broadcast([new msgClass(params)], options);
       };

--- a/src/secret_network_client.ts
+++ b/src/secret_network_client.ts
@@ -35,7 +35,6 @@ import {
   MsgSendParams,
   MsgSetWithdrawAddress,
   MsgSetWithdrawAddressParams,
-  MsgSnip20SetViewingKey,
   MsgStoreCode,
   MsgStoreCodeParams,
   MsgSubmitEvidence,
@@ -60,20 +59,15 @@ import {
   MsgWithdrawValidatorCommissionParams,
 } from ".";
 import { EncryptionUtils, EncryptionUtilsImpl } from "./encryption";
-import { AuthQuerier } from "./query";
-import { ComputeQuerier } from "./query";
-import { AminoMsg, Msg, MsgParams, ProtoMsg } from "./tx";
+import { PermitSigner } from "./extensions/access_control/permit/permit_signer";
 import {
-  AccountData,
-  AminoSigner,
-  AminoSignResponse,
-  encodeSecp256k1Pubkey,
-  isOfflineDirectSigner,
-  Pubkey,
-  Signer,
-  StdFee,
-  StdSignDoc,
-} from "./wallet_amino";
+  MsgCreateViewingKey,
+  MsgSetViewingKey,
+} from "./extensions/access_control/viewing_key/msgs";
+import {
+  CreateViewingKeyContractParams,
+  SetViewingKeyContractParams,
+} from "./extensions/access_control/viewing_key/params";
 import {
   MsgSnip20DecreaseAllowance,
   MsgSnip20IncreaseAllowance,
@@ -87,18 +81,21 @@ import {
   Snip20SendOptions,
   Snip20TransferOptions,
 } from "./extensions/snip20/types";
-import { MsgSnip721Send } from "./extensions/snip721";
+import { MsgSnip721Send, Snip721Querier } from "./extensions/snip721";
 import { Snip721SendOptions } from "./extensions/snip721/types";
-import { Snip721Querier } from "./extensions/snip721";
+import { AuthQuerier, ComputeQuerier } from "./query";
+import { AminoMsg, Msg, MsgParams, ProtoMsg } from "./tx";
 import {
-  MsgCreateViewingKey,
-  MsgSetViewingKey,
-} from "./extensions/access_control/viewing_key/msgs";
-import {
-  CreateViewingKeyContractParams,
-  SetViewingKeyContractParams,
-} from "./extensions/access_control/viewing_key/params";
-import { PermitSigner } from "./extensions/access_control/permit/permit_signer";
+  AccountData,
+  AminoSigner,
+  AminoSignResponse,
+  encodeSecp256k1Pubkey,
+  isOfflineDirectSigner,
+  Pubkey,
+  Signer,
+  StdFee,
+  StdSignDoc,
+} from "./wallet_amino";
 
 export type CreateClientOptions = {
   /** A gRPC-web url, by default on port 9091 */
@@ -113,6 +110,21 @@ export type CreateClientOptions = {
   encryptionSeed?: Uint8Array;
   /** `encryptionUtils` overrides the default {@link EncryptionUtilsImpl}. */
   encryptionUtils?: EncryptionUtils;
+};
+
+/**
+ * MsgTx is a function that broadcasts a single message transaction.
+ * It also has a `simulate()` method to execute the transaction without
+ * commiting it on-chain. This is helpful for gas estimation.
+ */
+export type MsgTx<T> = {
+  (params: T, txOptions?: TxOptions): Promise<Tx>;
+  simulate(
+    params: T,
+    txOptions?: TxOptions,
+  ): Promise<
+    import("./protobuf_stuff/cosmos/tx/v1beta1/service").SimulateResponse
+  >;
 };
 
 export enum BroadcastMode {
@@ -369,26 +381,25 @@ export type TxSender = {
    *   - staking         {@link MsgDelegate}
    *   - staking         {@link MsgEditValidator}
    *   - staking         {@link MsgUndelegate}
-   *
-   *
    */
   broadcast: (messages: Msg[], txOptions?: TxOptions) => Promise<Tx>;
 
+  /**
+   * Simulates a transaction on the node without broadcasting it to the chain.
+   * Can be used to get a gas estimation or to see the output without actually commiting a transaction on-chain.
+   * The input should be exactly how you'd use it in `broadcast`.
+   */
+  simulate: (
+    messages: Msg[],
+    txOptions?: TxOptions,
+  ) => Promise<
+    import("./protobuf_stuff/cosmos/tx/v1beta1/service").SimulateResponse
+  >;
+
   snip721: {
-    send: (
-      params: MsgExecuteContractParams<Snip721SendOptions>,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
-
-    setViewingKey: (
-      params: SetViewingKeyContractParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
-
-    createViewingKey: (
-      params: CreateViewingKeyContractParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    send: MsgTx<MsgExecuteContractParams<Snip721SendOptions>>;
+    setViewingKey: MsgTx<SetViewingKeyContractParams>;
+    createViewingKey: MsgTx<CreateViewingKeyContractParams>;
   };
 
   snip20: {
@@ -397,34 +408,16 @@ export type TxSender = {
     //getTransferHistory
     //getAllowance
     //getMinters
-    send: (
-      params: MsgExecuteContractParams<Snip20SendOptions>,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
-
-    transfer: (
-      params: MsgExecuteContractParams<Snip20TransferOptions>,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
-    increaseAllowance: (
-      params: MsgExecuteContractParams<Snip20IncreaseAllowanceOptions>,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
-
-    decreaseAllowance: (
-      params: MsgExecuteContractParams<Snip20DecreaseAllowanceOptions>,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
-
-    setViewingKey: (
-      params: SetViewingKeyContractParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
-
-    createViewingKey: (
-      params: CreateViewingKeyContractParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    send: MsgTx<MsgExecuteContractParams<Snip20SendOptions>>;
+    transfer: MsgTx<MsgExecuteContractParams<Snip20TransferOptions>>;
+    increaseAllowance: MsgTx<
+      MsgExecuteContractParams<Snip20IncreaseAllowanceOptions>
+    >;
+    decreaseAllowance: MsgTx<
+      MsgExecuteContractParams<Snip20DecreaseAllowanceOptions>
+    >;
+    setViewingKey: MsgTx<SetViewingKeyContractParams>;
+    createViewingKey: MsgTx<CreateViewingKeyContractParams>;
   };
 
   authz: {
@@ -433,128 +426,86 @@ export type TxSender = {
      * authorizations granted to the grantee. Each message should have only
      * one signer corresponding to the granter of the authorization.
      */
-    exec: (params: MsgExecParams, txOptions?: TxOptions) => Promise<Tx>;
+    exec: MsgTx<MsgExecParams>;
     /**
      * MsgGrant is a request type for Grant method. It declares authorization to the grantee
      * on behalf of the granter with the provided expiration time.
      */
-    grant: (params: MsgGrantParams, txOptions?: TxOptions) => Promise<Tx>;
+    grant: MsgTx<MsgGrantParams>;
     /**
      * MsgRevoke revokes any authorization with the provided sdk.Msg type on the
      * granter's account with that has been granted to the grantee.
      */
-    revoke: (params: MsgRevokeParams, txOptions?: TxOptions) => Promise<Tx>;
+    revoke: MsgTx<MsgRevokeParams>;
   };
   bank: {
     /** MsgMultiSend represents an arbitrary multi-in, multi-out send message. */
-    multiSend: (
-      params: MsgMultiSendParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    multiSend: MsgTx<MsgMultiSendParams>;
     /** MsgSend represents a message to send coins from one account to another. */
-    send: (params: MsgSendParams, txOptions?: TxOptions) => Promise<Tx>;
+    send: MsgTx<MsgSendParams>;
   };
   compute: {
     /** Execute a function on a contract */
-    executeContract: (
-      params: MsgExecuteContractParams<object>,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    executeContract: MsgTx<MsgExecuteContractParams<object>>;
     /** Instantiate a contract from code id */
-    instantiateContract: (
-      params: MsgInstantiateContractParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    instantiateContract: MsgTx<MsgInstantiateContractParams>;
     /** Upload a compiled contract to Secret Network */
-    storeCode: (
-      params: MsgStoreCodeParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    storeCode: MsgTx<MsgStoreCodeParams>;
   };
   crisis: {
     /** MsgVerifyInvariant represents a message to verify a particular invariance. */
-    verifyInvariant: (
-      params: MsgVerifyInvariantParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    verifyInvariant: MsgTx<MsgVerifyInvariantParams>;
   };
   distribution: {
     /**
      * MsgFundCommunityPool allows an account to directly
      * fund the community pool.
      */
-    fundCommunityPool: (
-      params: MsgFundCommunityPoolParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    fundCommunityPool: MsgTx<MsgFundCommunityPoolParams>;
     /**
      * MsgSetWithdrawAddress sets the withdraw address for
      * a delegator (or validator self-delegation).
      */
-    setWithdrawAddress: (
-      params: MsgSetWithdrawAddressParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    setWithdrawAddress: MsgTx<MsgSetWithdrawAddressParams>;
     /**
      * MsgWithdrawDelegatorReward represents delegation withdrawal to a delegator
      * from a single validator.
      */
-    withdrawDelegatorReward: (
-      params: MsgWithdrawDelegatorRewardParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    withdrawDelegatorReward: MsgTx<MsgWithdrawDelegatorRewardParams>;
     /**
      * MsgWithdrawValidatorCommission withdraws the full commission to the validator
      * address.
      */
-    withdrawValidatorCommission: (
-      params: MsgWithdrawValidatorCommissionParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    withdrawValidatorCommission: MsgTx<MsgWithdrawValidatorCommissionParams>;
   };
   evidence: {
     /**
      * MsgSubmitEvidence represents a message that supports submitting arbitrary
      * Evidence of misbehavior such as equivocation or counterfactual signing.
      */
-    submitEvidence: (
-      params: MsgSubmitEvidenceParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    submitEvidence: MsgTx<MsgSubmitEvidenceParams>;
   };
   feegrant: {
     /**
      * MsgGrantAllowance adds permission for Grantee to spend up to Allowance
      * of fees from the account of Granter.
      */
-    grantAllowance: (
-      params: MsgGrantAllowanceParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    grantAllowance: MsgTx<MsgGrantAllowanceParams>;
     /** MsgRevokeAllowance removes any existing Allowance from Granter to Grantee. */
-    revokeAllowance: (
-      params: MsgRevokeAllowanceParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    revokeAllowance: MsgTx<MsgRevokeAllowanceParams>;
   };
   gov: {
     /** MsgDeposit defines a message to submit a deposit to an existing proposal. */
-    deposit: (params: MsgDepositParams, txOptions?: TxOptions) => Promise<Tx>;
+    deposit: MsgTx<MsgDepositParams>;
     /**
      * MsgSubmitProposal defines an sdk.Msg type that supports submitting arbitrary
      * proposal Content.
      */
-    submitProposal: (
-      params: MsgSubmitProposalParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    submitProposal: MsgTx<MsgSubmitProposalParams>;
     /** MsgVote defines a message to cast a vote. */
-    vote: (params: MsgVoteParams, txOptions?: TxOptions) => Promise<Tx>;
+    vote: MsgTx<MsgVoteParams>;
     /** MsgVoteWeighted defines a message to cast a vote, with an option to split the vote. */
-    voteWeighted: (
-      params: MsgVoteWeightedParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    voteWeighted: MsgTx<MsgVoteWeightedParams>;
   };
   ibc: {
     /**
@@ -562,35 +513,23 @@ export type TxSender = {
      * ICS20 enabled chains. See ICS Spec here:
      * https://github.com/cosmos/ics/tree/master/spec/ics-020-fungible-token-transfer#data-structures
      */
-    transfer: (params: MsgTransferParams, txOptions?: TxOptions) => Promise<Tx>;
+    transfer: MsgTx<MsgTransferParams>;
   };
   slashing: {
     /** MsgUnjail defines a message to release a validator from jail. */
-    unjail: (params: MsgUnjailParams, txOptions?: TxOptions) => Promise<Tx>;
+    unjail: MsgTx<MsgUnjailParams>;
   };
   staking: {
     /** MsgBeginRedelegate defines an SDK message for performing a redelegation of coins from a delegator and source validator to a destination validator. */
-    beginRedelegate: (
-      params: MsgBeginRedelegateParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    beginRedelegate: MsgTx<MsgBeginRedelegateParams>;
     /** MsgCreateValidator defines an SDK message for creating a new validator. */
-    createValidator: (
-      params: MsgCreateValidatorParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    createValidator: MsgTx<MsgCreateValidatorParams>;
     /** MsgDelegate defines an SDK message for performing a delegation of coins from a delegator to a validator. */
-    delegate: (params: MsgDelegateParams, txOptions?: TxOptions) => Promise<Tx>;
+    delegate: MsgTx<MsgDelegateParams>;
     /** MsgEditValidator defines an SDK message for editing an existing validator. */
-    editValidator: (
-      params: MsgEditValidatorParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    editValidator: MsgTx<MsgEditValidatorParams>;
     /** MsgUndelegate defines an SDK message for performing an undelegation from a delegate and a validator */
-    undelegate: (
-      params: MsgUndelegateParams,
-      txOptions?: TxOptions,
-    ) => Promise<Tx>;
+    undelegate: MsgTx<MsgUndelegateParams>;
   };
 };
 
@@ -719,14 +658,21 @@ export class SecretNetworkClient {
 
     this.utils = { accessControl: { permit: new PermitSigner(this.wallet) } };
 
-    const doMsg = (msgClass: any) => {
-      return (params: MsgParams, options?: TxOptions) => {
+    // TODO fix this any
+    const doMsg = (msgClass: any): MsgTx<any> => {
+      const func = (params: MsgParams, options?: TxOptions) => {
         return this.tx.broadcast([new msgClass(params)], options);
       };
+      func.simulate = (params: MsgParams, options?: TxOptions) => {
+        return this.tx.simulate([new msgClass(params)], options);
+      };
+
+      return func;
     };
 
     this.tx = {
       broadcast: this.signAndBroadcast.bind(this),
+      simulate: this.simulate.bind(this),
 
       snip20: {
         send: doMsg(MsgSnip20Send),
@@ -1022,19 +968,15 @@ export class SecretNetworkClient {
     }
   }
 
-  private async signAndBroadcast(
+  private async prepareAndSign(
     messages: Msg[],
     txOptions?: TxOptions,
-  ): Promise<Tx> {
+  ): Promise<[Uint8Array, ComputeMsgToNonce]> {
     const gasLimit = txOptions?.gasLimit ?? 25_000;
     const gasPriceInFeeDenom = txOptions?.gasPriceInFeeDenom ?? 0.25;
     const feeDenom = txOptions?.feeDenom ?? "uscrt";
     const memo = txOptions?.memo ?? "";
-    const waitForCommit = txOptions?.waitForCommit ?? true;
-    const broadcastTimeoutMs = txOptions?.broadcastTimeoutMs ?? 60_000;
-    const broadcastCheckIntervalMs =
-      txOptions?.broadcastCheckIntervalMs ?? 6_000;
-    const broadcastMode = txOptions?.broadcastMode ?? BroadcastMode.Sync;
+
     const explicitSignerData = txOptions?.explicitSignerData;
 
     const [txRaw, nonces] = await this.sign(
@@ -1051,9 +993,25 @@ export class SecretNetworkClient {
       memo,
       explicitSignerData,
     );
+
     const txBytes = (
       await import("./protobuf_stuff/cosmos/tx/v1beta1/tx")
     ).TxRaw.encode(txRaw).finish();
+
+    return [txBytes, nonces];
+  }
+
+  private async signAndBroadcast(
+    messages: Msg[],
+    txOptions?: TxOptions,
+  ): Promise<Tx> {
+    const waitForCommit = txOptions?.waitForCommit ?? true;
+    const broadcastTimeoutMs = txOptions?.broadcastTimeoutMs ?? 60_000;
+    const broadcastCheckIntervalMs =
+      txOptions?.broadcastCheckIntervalMs ?? 6_000;
+    const broadcastMode = txOptions?.broadcastMode ?? BroadcastMode.Sync;
+
+    const [txBytes, nonces] = await this.prepareAndSign(messages, txOptions);
 
     return this.broadcastTx(
       txBytes,
@@ -1063,6 +1021,16 @@ export class SecretNetworkClient {
       waitForCommit,
       nonces,
     );
+  }
+
+  private async simulate(
+    messages: Msg[],
+    txOptions?: TxOptions,
+  ): Promise<
+    import("./protobuf_stuff/cosmos/tx/v1beta1/service").SimulateResponse
+  > {
+    const [txBytes] = await this.prepareAndSign(messages, txOptions);
+    return this.txService.simulate({ txBytes });
   }
 
   /**

--- a/src/secret_network_client.ts
+++ b/src/secret_network_client.ts
@@ -115,7 +115,7 @@ export type CreateClientOptions = {
 /**
  * MsgTx is a function that broadcasts a single message transaction.
  * It also has a `simulate()` method to execute the transaction without
- * commiting it on-chain. This is helpful for gas estimation.
+ * committing it on-chain. This is helpful for gas estimation.
  */
 export type MsgTx<T> = {
   (params: T, txOptions?: TxOptions): Promise<Tx>;
@@ -386,7 +386,7 @@ export type TxSender = {
 
   /**
    * Simulates a transaction on the node without broadcasting it to the chain.
-   * Can be used to get a gas estimation or to see the output without actually commiting a transaction on-chain.
+   * Can be used to get a gas estimation or to see the output without actually committing a transaction on-chain.
    * The input should be exactly how you'd use it in `broadcast`.
    */
   simulate: (

--- a/test.sh
+++ b/test.sh
@@ -4,4 +4,4 @@ if node --version | awk -F '[v.]' '{if($2 > 16){exit 0}else{exit 1}}' ; then
     export NODE_OPTIONS=--openssl-legacy-provider
 fi
 
-npx jest --runInBand
+npx jest --runInBand "$@"

--- a/test/test.ts
+++ b/test/test.ts
@@ -345,16 +345,11 @@ describe("tx.bank", () => {
     const aBefore = await getBalance(secretjs, accounts[0].address);
     const cBefore = await getBalance(secretjs, accounts[2].address);
 
-    const sim = await secretjs.tx.bank.send.simulate(
-      {
-        fromAddress: accounts[0].address,
-        toAddress: accounts[2].address,
-        amount: [{ denom: "uscrt", amount: "1" }],
-      },
-      {
-        gasLimit: 20_000,
-      },
-    );
+    const sim = await secretjs.tx.bank.send.simulate({
+      fromAddress: accounts[0].address,
+      toAddress: accounts[2].address,
+      amount: [{ denom: "uscrt", amount: "1" }],
+    });
 
     const gasLimit = Math.ceil(Number(sim.gasInfo!.gasUsed) * 1.15);
 
@@ -560,22 +555,23 @@ describe("tx.compute", () => {
     });
   });
 
-  test("MsgExecuteContract", async () => {
+  test("MsgExecuteContract xyz", async () => {
     const { secretjs } = accounts[0];
 
-    const txStore = await secretjs.tx.compute.storeCode(
-      {
-        sender: accounts[0].address,
-        wasmByteCode: fs.readFileSync(
-          `${__dirname}/snip721.wasm.gz`,
-        ) as Uint8Array,
-        source: "",
-        builder: "",
-      },
-      {
-        gasLimit: 5_000_000,
-      },
-    );
+    const storeInput = {
+      sender: accounts[0].address,
+      wasmByteCode: fs.readFileSync(
+        `${__dirname}/snip721.wasm.gz`,
+      ) as Uint8Array,
+      source: "",
+      builder: "",
+    };
+
+    const simStore = await secretjs.tx.compute.storeCode.simulate(storeInput);
+
+    const txStore = await secretjs.tx.compute.storeCode(storeInput, {
+      gasLimit: Math.ceil(Number(simStore.gasInfo!.gasUsed) * 1.1),
+    });
 
     expect(txStore.code).toBe(0);
 
@@ -587,29 +583,32 @@ describe("tx.compute", () => {
       codeInfo: { codeHash },
     } = await secretjs.query.compute.code(codeId);
 
-    const txInit = await secretjs.tx.compute.instantiateContract(
-      {
-        sender: accounts[0].address,
-        codeId,
-        // codeHash, // Test MsgInstantiateContract without codeHash
-        initMsg: {
-          name: "SecretJS NFTs",
-          symbol: "YOLO",
-          admin: accounts[0].address,
-          entropy: "a2FraS1waXBpCg==",
-          royalty_info: {
-            decimal_places_in_rates: 4,
-            royalties: [{ recipient: accounts[0].address, rate: 700 }],
-          },
-          config: { public_token_supply: true },
+    const initInput = {
+      sender: accounts[0].address,
+      codeId,
+      // codeHash, // Test MsgInstantiateContract without codeHash
+      initMsg: {
+        name: "SecretJS NFTs",
+        symbol: "YOLO",
+        admin: accounts[0].address,
+        entropy: "a2FraS1waXBpCg==",
+        royalty_info: {
+          decimal_places_in_rates: 4,
+          royalties: [{ recipient: accounts[0].address, rate: 700 }],
         },
-        label: `label-${Date.now()}`,
-        initFunds: [],
+        config: { public_token_supply: true },
       },
-      {
-        gasLimit: 5_000_000,
-      },
+      label: `label-${Date.now()}`,
+      initFunds: [],
+    };
+
+    const simInit = await secretjs.tx.compute.instantiateContract.simulate(
+      initInput,
     );
+
+    const txInit = await secretjs.tx.compute.instantiateContract(initInput, {
+      gasLimit: Math.ceil(Number(simInit.gasInfo!.gasUsed) * 1.1),
+    });
 
     expect(txInit.code).toBe(0);
 
@@ -650,8 +649,10 @@ describe("tx.compute", () => {
       sentFunds: [],
     });
 
+    const simExec = await secretjs.tx.simulate([addMinterMsg, mintMsg]);
+
     const tx = await secretjs.tx.broadcast([addMinterMsg, mintMsg], {
-      gasLimit: 5_000_000,
+      gasLimit: Math.ceil(Number(simExec.gasInfo!.gasUsed) * 1.1),
     });
 
     expect(tx.code).toBe(0);


### PR DESCRIPTION
`secretjs.tx.simulate()` allows simulating a tx before broadcasting, for getting gas estimation or seeing the expected result without committing a transaction on-chain.