### PR TITLE
Fixed GetOwnedTokens method for SNIP-721 extension

### DIFF
--- a/src/extensions/snip721/msg/GetTokens.ts
+++ b/src/extensions/snip721/msg/GetTokens.ts
@@ -17,9 +17,11 @@ export interface Snip721GetTokensRequest {
 
 export interface Snip721GetTokensRequestWithPermit {
   with_permit: {
-    tokens: {
-      owner: string;
-    };
+    query: {
+      tokens: {
+        owner: string;
+      };
+    },
     permit: Permit;
   };
 }

--- a/src/extensions/snip721/query.ts
+++ b/src/extensions/snip721/query.ts
@@ -120,14 +120,16 @@ export class Snip721Querier extends ComputeQuerier {
       return await this.queryContract<
         Snip721GetTokensRequestWithPermit,
         Snip721GetTokensResponse
-      >({
+        >({
         contractAddress: contract.address,
         codeHash: contract.codeHash,
         query: {
           with_permit: {
             permit: auth.permit,
-            tokens: {
-              owner,
+            query: {
+              tokens: {
+                owner,
+              },
             },
           },
         },

--- a/test/snip721.test.ts
+++ b/test/snip721.test.ts
@@ -501,7 +501,7 @@ describe("query.snip721", () => {
 
     expect(tokens.token_list.tokens.length).toEqual(1);
 
-    let permit = await secretjs.utils.accessControl.permit.sign(accounts[0].address, "secretdev-1", "Test", [contractAddress], ["owner"])
+    let permit = await secretjs.utils.accessControl.permit.sign(accounts[0].address, "secretdev-1", "Test", [contractAddress], ["owner"], false)
 
     let tokens2 = await secretjs.query.snip721.GetOwnedTokens({
       contract: { address: contractAddress, codeHash },

--- a/test/snip721.test.ts
+++ b/test/snip721.test.ts
@@ -500,5 +500,15 @@ describe("query.snip721", () => {
     });
 
     expect(tokens.token_list.tokens.length).toEqual(1);
+
+    let permit = await secretjs.utils.accessControl.permit.sign(accounts[0].address, "secretdev-1", "Test", [contractAddress], ["owner"])
+
+    let tokens2 = await secretjs.query.snip721.GetOwnedTokens({
+      contract: { address: contractAddress, codeHash },
+      owner: accounts[0].address,
+      auth: { permit: permit },
+    });
+
+    expect(tokens2.token_list.tokens.length).toEqual(1);
   });
 });


### PR DESCRIPTION
Fixed the GetOwnedTokens method for the SNIP-721 extension.

Query param was missing: https://github.com/baedrik/snip721-reference-impl/blob/master/README.md#withpermit