### PR TITLE
fix: Use Ledger

### DIFF
--- a/src/wallet_metamask.ts
+++ b/src/wallet_metamask.ts
@@ -66,7 +66,12 @@ export class MetaMaskWallet {
 
     // strip leading 0x and extract recovery id
     const sig = fromHex(sigResult.slice(2, -2));
-    const recoveryId = parseInt(sigResult.slice(-2), 16) - 27;
+    let recoveryId = parseInt(sigResult.slice(-2), 16) - 27;
+
+    // When a Ledger is used, this value doesn't need to be adjusted 
+    if (recoveryId < 0) {
+      recoveryId += 27;
+    }
 
     const eip191MessagePrefix = toUtf8("\x19Ethereum Signed Message:\n");
     const rawMsgLength = toUtf8(String(rawMsg.length));


### PR DESCRIPTION
Ledger already returns a valid recovery ID. Right now it returns `Cannot recover signature: invalid recovery bit` when getting the secret address because the resulting value is usually `-26`.

see:

```js
    if (recovery !== 0 && recovery !== 1) {
      throw new Error('Cannot recover signature: invalid recovery bit');
    }
```


https://github.com/paulmillr/noble-secp256k1/blob/ba89ec38322f268a58ba5457045eeef213faa9c9/index.ts#L471-L473