### PR TITLE
Fix README.md get codeHash functions name

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,11 +554,11 @@ DenomsMetadata queries the client metadata of a given coin denomination.
 
 DenomsMetadata queries the client metadata for all registered coin denominations.
 
-#### `secretjs.query.compute.contractCodeHash()`
+#### `secretjs.query.compute.codeHashByContractAddress()`
 
 Get codeHash of a Secret Contract.
 
-#### `secretjs.query.compute.codeHash()`
+#### `secretjs.query.compute.codeHashByCodeId()`
 
 Get codeHash from a code id.
 


### PR DESCRIPTION
accordingly to query/compute.ts > ComputeQuerier lines 92 and 110 give us the correct functions names: 
async codeHashByContractAddress(..)
async codeHashByCodeId(...)