### PR TITLE
perf(npm): move sinon to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "miscreant": "0.3.2",
     "pako": "2.0.4",
     "protobufjs": "6.11.3",
-    "secure-random": "1.1.2",
-    "sinon": "14.0.0"
+    "secure-random": "1.1.2"
   },
   "devDependencies": {
     "@confio/relayer": "0.7.0",
@@ -59,6 +58,7 @@
     "jest": "27.4.7",
     "node-polyfill-webpack-plugin": "1.1.4",
     "prettier": "2.5.1",
+    "sinon": "14.0.0",
     "ts-jest": "27.1.3",
     "ts-loader": "9.2.6",
     "ts-node": "^10.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -869,12 +869,19 @@
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@^10.0.2":
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz#d10549ed1f423d80639c528b6c7f5a1017747d0c"
-  integrity sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==
+"@sinonjs/commons@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.0.tgz#beb434fe875d965265e04722ccfc21df7f755d72"
+  integrity sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==
   dependencies:
-    "@sinonjs/commons" "^2.0.0"
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^10.0.2":
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz#55fdff1ecab9f354019129daf4df0dd4d923ea66"
+  integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
+  dependencies:
+    "@sinonjs/commons" "^3.0.0"
 
 "@sinonjs/fake-timers@^8.0.1":
   version "8.1.0"


### PR DESCRIPTION
This reduces the data that downstream consumers of `secretjs` need to download by **~8MB**, amounting to **15-25%** of the stuff that needs to be downloaded from NPM in order to develop for Secret (depending on what package manager is used) :grinning:

I haven't checked if there are other libraries that could also be moved to `devDependencies` :thinking: But this one stood out to me as I was optimizing download sizes for `@fadroma/scrt` (which is not dead, just meditating to achieve higher consciousness :alien:) so I thought I'd lend a hand with this stuff :hand: 