### PR TITLE
fix(test): make test.sh portable

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
`/bin/bash` is not guaranteed to be there; the standard way to find Bash is by using `/usr/bin/env` and the `PATH` environment variable.

See: https://www.oreilly.com/library/view/bash-cookbook/0596526784/ch15s01.html
See: https://unix.stackexchange.com/questions/569964/posix-shell-scripts-shebang-bin-sh-vs-usr-bin-env-sh-any-difference#comment1060096_569964