### PR TITLE
`signAmino()`: use `memo` from signed transaction instead from the caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog & Version Info
 
+## 1.12.5
+
+Fix `signAmino()` to broadcast the memo from the signer (wallet) instead of the memo from the caller.
+
 ## 1.12.4
 
 Fix `txsQuery()` for Cosmos SDK v0.46+ chains

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secretjs",
   "description": "The JavaScript SDK for Secret Network",
-  "version": "1.12.4",
+  "version": "1.12.5-beta.1",
   "license": "MIT",
   "author": "SCRT Labs",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secretjs",
   "description": "The JavaScript SDK for Secret Network",
-  "version": "1.12.5-beta.1",
+  "version": "1.12.5-beta.2",
   "license": "MIT",
   "author": "SCRT Labs",
   "bugs": {

--- a/src/secret_network_client.ts
+++ b/src/secret_network_client.ts
@@ -1904,7 +1904,7 @@ export class SecretNetworkClient {
             return asProto;
           }),
         ),
-        memo: memo,
+        memo: signDoc.memo, // memo might have been changed by the wallet before signing
       },
     };
     const txBodyBytes = await this.encodeTx(txBody);

--- a/src/secret_network_client.ts
+++ b/src/secret_network_client.ts
@@ -1904,7 +1904,7 @@ export class SecretNetworkClient {
             return asProto;
           }),
         ),
-        memo: signDoc.memo, // memo might have been changed by the wallet before signing
+        memo: signed.memo, // memo might have been changed by the wallet before signing
       },
     };
     const txBodyBytes = await this.encodeTx(txBody);


### PR DESCRIPTION
Fixes https://github.com/scrtlabs/secret.js/issues/161

Before now, `signAmino()` used `memo` from the caller. This made it so if the signer changed the `memo` before signing, the transaction would fail because of a signature mismatch.

Note: this bug only existed in `signAmino()` and not in `signDirect()`.