### PR TITLE
chore: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Notes:
 
 1. MetaMask supports mobile!
 2. MetaMask supports Ledger.
-3. You might want to pass `encryptionSeed` to `SecretNetworkClient.create()` to use the same encryption key for the user across sessions. This value should be a true random 32 byte number that is stored securly in your app, such that only the user can decrypt it. This can also be a `sha256(user_password)` but might impair UX.
+3. You might want to pass `encryptionSeed` to `SecretNetworkClient.create()` to use the same encryption key for the user across sessions. This value should be a true random 32 byte number that is stored securely in your app, such that only the user can decrypt it. This can also be a `sha256(user_password)` but might impair UX.
 4. See Keplr's [`getOfflineSignerOnlyAmino()`](#windowkeplrgetofflinesigneronlyamino) for list of unsupported transactions.
 
 <img src="./media/metamask-signing-example.jpg" width="55%" style="border-radius: 10px;" />


### PR DESCRIPTION
fix a typo: `securly`->`securely`